### PR TITLE
Adding some terraform

### DIFF
--- a/terrform/.gitignore
+++ b/terrform/.gitignore
@@ -158,3 +158,55 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+
+### Terragrunt ###
+**/.terragrunt-cache/*
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+.terraform
+.terragrunt-cache
+*__pycache__*
+# Ignore GPG keys
+.pgp
+
+.DS_Store
+
+# Ignore vscode files
+.vscode

--- a/terrform/README.md
+++ b/terrform/README.md
@@ -1,0 +1,3 @@
+# Робочий репозиторій для мінікурсу "Вступ до MLOps/LLMOps"
+
+Курс: https://github.com/dmytro-spodarets/Introduction-to-MLOps-LLMOps-UA

--- a/terrform/apprunners.tf
+++ b/terrform/apprunners.tf
@@ -1,0 +1,90 @@
+module "app_runner_label_studio" {
+  source  = "terraform-aws-modules/app-runner/aws"
+  version = "1.2.0"
+
+  service_name = "label_studio_${var.environment}"
+
+  # IAM instance profile permissions to access secrets
+  instance_policy_statements = {
+    GetSecretValue = {
+      actions = [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      resources = [
+        module.s3_assets.s3_bucket_arn,
+        "${module.s3_assets.s3_bucket_arn}/*"
+      ]
+    }
+  }
+  create_instance_iam_role = true
+  instance_iam_role_name   = "apprunner-label-studio-role-${var.environment}"
+
+  # role used to authenticate apprunner in ECR, (can be reused by all our apprunners)
+  create_access_iam_role = false
+
+  source_configuration = {
+    auto_deployments_enabled = false
+    authentication_configuration = {
+      access_role_arn = module.apprunner_access_role.iam_role_arn
+    }
+    image_repository = {
+      image_configuration = {
+        port = 8080
+        runtime_environment_variables = {
+          SOME_VARIABLE = "some_value"
+        }
+        #runtime_environment_secrets = {
+        #  SOME_SECRET = aws_secretsmanager_secret.this.arn
+        #}
+      }
+      image_identifier      = module.ecr["label_studio"].repository_url #"public.ecr.aws/aws-containers/hello-app-runner:latest"
+      image_repository_type = "ECR"
+    }
+  }
+
+  # # Requires manual intervention to validate records
+  # # https://github.com/hashicorp/terraform-provider-aws/issues/23460
+  # create_custom_domain_association = true
+  # hosted_zone_id                   = "<TODO>"
+  # domain_name                      = "<TODO>"
+  # enable_www_subdomain             = true
+
+  create_vpc_connector          = true
+  vpc_connector_subnets         = module.vpc.private_subnets
+  vpc_connector_security_groups = [module.security_group_apprunner_connector.security_group_id]
+  network_configuration = {
+    egress_configuration = {
+      egress_type = "DEFAULT"
+    }
+  }
+  enable_observability_configuration = false
+}
+
+
+
+module "security_group_apprunner_connector" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "apprunner-connector"
+  description = "Security group for AppRunner connector"
+  vpc_id      = module.vpc.vpc_id
+
+  egress_rules       = ["http-80-tcp"]
+  egress_cidr_blocks = module.vpc.public_subnets_cidr_blocks
+}
+
+module "security_group_apprunner_endpoint" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "apprunner-vpc-endpoints"
+  description = "Security group for Apprunner VPC Endpoints"
+  vpc_id      = module.vpc.vpc_id
+
+  egress_rules       = ["https-443-tcp"]
+  egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+}

--- a/terrform/ecr.tf
+++ b/terrform/ecr.tf
@@ -1,0 +1,25 @@
+module "ecr" {
+  source          = "terraform-aws-modules/ecr/aws"
+  version         = "1.6.0"
+  for_each        = toset([for k, v in local.config.ecr_repositories : v])
+  repository_name = each.value
+
+  repository_read_write_access_arns = [module.apprunner_access_role.iam_role_arn]
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep last 10 images",
+        selection = {
+          tagStatus = "tagged",
+          #tagPrefixList = ["v"],
+          countType   = "imageCountMoreThan",
+          countNumber = 10
+        },
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terrform/env-config.tf
+++ b/terrform/env-config.tf
@@ -1,0 +1,26 @@
+locals {
+  global_config = {
+    vpc_cidr = "10.${random_integer.network_num.result}.0.0/16"
+    vpc_name = "ml-${var.environment}"
+    az_num   = 3
+    azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+    ecr_repositories = {
+      label_studio = "label_studio"
+      dstack       = "dstack"
+      mlflow       = "mlflow"
+    }
+  }
+}
+
+locals {
+  env_config = {
+    dev = {
+
+    }
+  }
+
+  config = merge(
+    local.global_config,
+    local.env_config[var.environment]
+  )
+}

--- a/terrform/iam.tf
+++ b/terrform/iam.tf
@@ -1,0 +1,50 @@
+module "iam_policy_apprunner_access" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-policy"
+
+  name        = "apprunner-access-policy-${var.environment}"
+  path        = "/"
+  description = "Access to ECR to Apprunner"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImages",
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+module "apprunner_access_role" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+
+  # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
+  allow_self_assume_role = true
+
+  trusted_role_services = [
+    "build.apprunner.amazonaws.com"
+  ]
+
+  custom_role_policy_arns = [
+    module.iam_policy_apprunner_access.arn
+  ]
+
+  create_role             = true
+  create_instance_profile = false
+
+  role_name         = "apprunner-access-role-${var.environment}"
+  role_requires_mfa = false
+
+  attach_admin_policy = false
+
+}

--- a/terrform/providers.tf
+++ b/terrform/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.21.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Terraform   = "true"
+    }
+  }
+}

--- a/terrform/storage.tf
+++ b/terrform/storage.tf
@@ -1,0 +1,29 @@
+module "s3_assets" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "3.15.1"
+
+  bucket_prefix       = "assets-${var.environment}-"
+  acl                 = "private"
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  force_destroy       = true
+
+  cors_rule = [ # https://labelstud.io/guide/persistent_storage#Configure-CORS-for-the-S3-bucket
+    {
+      allowed_methods = ["GET", "PUT", "POST", "DELETE", "HEAD"]
+      allowed_origins = ["*"]
+      allowed_headers = ["*"]
+      expose_headers = [
+        "x-amz-server-side-encryption",
+        "x-amz-request-id",
+        "x-amz-id-2"
+      ]
+      max_age_seconds = 3000
+    }
+  ]
+
+  versioning = {
+    enabled = false #do we need versioning?
+  }
+}

--- a/terrform/variables.tf
+++ b/terrform/variables.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  type    = string
+  default = "dev"
+  validation {
+    condition     = contains(["dev", "stage", "prod"], var.environment)
+    error_message = "Environment must be one of \"dev\", \"stage\", or \"prod\""
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "eu-west-1"
+}
+

--- a/terrform/vpc.tf
+++ b/terrform/vpc.tf
@@ -1,0 +1,32 @@
+resource "random_integer" "network_num" {
+  min = 10
+  max = 50
+  keepers = {
+    environment = var.environment
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.1.2"
+
+  name = local.config.vpc_name
+  cidr = local.config.vpc_cidr
+
+  azs              = local.config.azs
+  private_subnets  = [for k, v in local.config.azs : cidrsubnet(local.config.vpc_cidr, 8, k)]
+  public_subnets   = [for k, v in local.config.azs : cidrsubnet(local.config.vpc_cidr, 8, k + 4)]
+  database_subnets = [for k, v in local.config.azs : cidrsubnet(local.config.vpc_cidr, 8, k + 8)]
+
+
+  enable_nat_gateway      = false # not sure we need NAT GW in our case
+  single_nat_gateway      = true
+  enable_dns_hostnames    = true
+  enable_dns_support      = true
+  map_public_ip_on_launch = false
+
+  create_database_subnet_group = true
+
+}


### PR DESCRIPTION
This PR is for preview only, not ready to be merged, just POC

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # random_integer.network_num will be created
  + resource "random_integer" "network_num" {
      + id      = (known after apply)
      + keepers = {
          + "environment" = "dev"
        }
      + max     = 50
      + min     = 10
      + result  = (known after apply)
    }

  # module.app_runner_label_studio.data.aws_iam_policy_document.instance[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "instance" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:DeleteObject",
              + "s3:GetObject",
              + "s3:ListBucket",
              + "s3:PutObject",
            ]
          + resources = (known after apply)
          + sid       = "GetSecretValue"
        }
    }

  # module.app_runner_label_studio.aws_apprunner_service.this[0] will be created
  + resource "aws_apprunner_service" "this" {
      + arn                            = (known after apply)
      + auto_scaling_configuration_arn = (known after apply)
      + id                             = (known after apply)
      + service_id                     = (known after apply)
      + service_name                   = "label_studio_dev"
      + service_url                    = (known after apply)
      + status                         = (known after apply)
      + tags_all                       = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }

      + instance_configuration {
          + cpu               = "1024"
          + instance_role_arn = (known after apply)
          + memory            = "2048"
        }

      + network_configuration {}

      + source_configuration {
          + auto_deployments_enabled = false
        }
    }

  # module.app_runner_label_studio.aws_apprunner_vpc_connector.this[0] will be created
  + resource "aws_apprunner_vpc_connector" "this" {
      + arn                    = (known after apply)
      + id                     = (known after apply)
      + security_groups        = (known after apply)
      + status                 = (known after apply)
      + subnets                = (known after apply)
      + tags_all               = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }
      + vpc_connector_name     = "label_studio_dev"
      + vpc_connector_revision = (known after apply)
    }

  # module.app_runner_label_studio.aws_iam_policy.instance[0] will be created
  + resource "aws_iam_policy" "instance" {
      + arn         = (known after apply)
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = "apprunner-label-studio-role-dev-"
      + path        = "/"
      + policy      = (known after apply)
      + policy_id   = (known after apply)
      + tags_all    = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }
    }

  # module.app_runner_label_studio.aws_iam_role.instance[0] will be created
  + resource "aws_iam_role" "instance" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "tasks.apprunner.amazonaws.com"
                        }
                      + Sid       = "InstanceAssumeRole"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = true
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = "apprunner-label-studio-role-dev-"
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }
      + unique_id             = (known after apply)
    }

  # module.app_runner_label_studio.aws_iam_role_policy_attachment.instance[0] will be created
  + resource "aws_iam_role_policy_attachment" "instance" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = (known after apply)
    }

  # module.apprunner_access_role.aws_iam_role.this[0] will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Condition = {
                          + ArnLike = {
                              + "aws:PrincipalArn" = "arn:aws:iam::906025916959:role/apprunner-access-role-dev"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Sid       = "ExplicitSelfRoleAssumption"
                    },
                  + {
                      + Action    = [
                          + "sts:TagSession",
                          + "sts:AssumeRole",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS     = []
                          + Service = "build.apprunner.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "apprunner-access-role-dev"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }
      + unique_id             = (known after apply)
    }

  # module.apprunner_access_role.aws_iam_role_policy_attachment.custom[0] will be created
  + resource "aws_iam_role_policy_attachment" "custom" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "apprunner-access-role-dev"
    }

  # module.ecr["dstack"].data.aws_iam_policy_document.repository[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "repository" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions = [
              + "ecr:BatchCheckLayerAvailability",
              + "ecr:BatchGetImage",
              + "ecr:DescribeImageScanFindings",
              + "ecr:DescribeImages",
              + "ecr:DescribeRepositories",
              + "ecr:GetAuthorizationToken",
              + "ecr:GetDownloadUrlForLayer",
              + "ecr:GetLifecyclePolicy",
              + "ecr:GetLifecyclePolicyPreview",
              + "ecr:GetRepositoryPolicy",
              + "ecr:ListImages",
              + "ecr:ListTagsForResource",
            ]
          + sid     = "PrivateReadOnly"

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
      + statement {
          + actions = [
              + "ecr:CompleteLayerUpload",
              + "ecr:InitiateLayerUpload",
              + "ecr:PutImage",
              + "ecr:UploadLayerPart",
            ]
          + sid     = "ReadWrite"

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # module.ecr["dstack"].aws_ecr_lifecycle_policy.this[0] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Keep last 10 images"
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 10
                          + countType   = "imageCountMoreThan"
                          + tagStatus   = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "dstack"
    }

  # module.ecr["dstack"].aws_ecr_repository.this[0] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "IMMUTABLE"
      + name                 = "dstack"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
      + tags_all             = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }

      + encryption_configuration {
          + encryption_type = "AES256"
          + kms_key         = (known after apply)
        }

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # module.ecr["dstack"].aws_ecr_repository_policy.this[0] will be created
  + resource "aws_ecr_repository_policy" "this" {
      + id          = (known after apply)
      + policy      = (known after apply)
      + registry_id = (known after apply)
      + repository  = "dstack"
    }

  # module.ecr["label_studio"].data.aws_iam_policy_document.repository[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "repository" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions = [
              + "ecr:BatchCheckLayerAvailability",
              + "ecr:BatchGetImage",
              + "ecr:DescribeImageScanFindings",
              + "ecr:DescribeImages",
              + "ecr:DescribeRepositories",
              + "ecr:GetAuthorizationToken",
              + "ecr:GetDownloadUrlForLayer",
              + "ecr:GetLifecyclePolicy",
              + "ecr:GetLifecyclePolicyPreview",
              + "ecr:GetRepositoryPolicy",
              + "ecr:ListImages",
              + "ecr:ListTagsForResource",
            ]
          + sid     = "PrivateReadOnly"

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
      + statement {
          + actions = [
              + "ecr:CompleteLayerUpload",
              + "ecr:InitiateLayerUpload",
              + "ecr:PutImage",
              + "ecr:UploadLayerPart",
            ]
          + sid     = "ReadWrite"

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # module.ecr["label_studio"].aws_ecr_lifecycle_policy.this[0] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Keep last 10 images"
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 10
                          + countType   = "imageCountMoreThan"
                          + tagStatus   = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "label_studio"
    }

  # module.ecr["label_studio"].aws_ecr_repository.this[0] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "IMMUTABLE"
      + name                 = "label_studio"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
      + tags_all             = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }

      + encryption_configuration {
          + encryption_type = "AES256"
          + kms_key         = (known after apply)
        }

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # module.ecr["label_studio"].aws_ecr_repository_policy.this[0] will be created
  + resource "aws_ecr_repository_policy" "this" {
      + id          = (known after apply)
      + policy      = (known after apply)
      + registry_id = (known after apply)
      + repository  = "label_studio"
    }

  # module.ecr["mlflow"].data.aws_iam_policy_document.repository[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "repository" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions = [
              + "ecr:BatchCheckLayerAvailability",
              + "ecr:BatchGetImage",
              + "ecr:DescribeImageScanFindings",
              + "ecr:DescribeImages",
              + "ecr:DescribeRepositories",
              + "ecr:GetAuthorizationToken",
              + "ecr:GetDownloadUrlForLayer",
              + "ecr:GetLifecyclePolicy",
              + "ecr:GetLifecyclePolicyPreview",
              + "ecr:GetRepositoryPolicy",
              + "ecr:ListImages",
              + "ecr:ListTagsForResource",
            ]
          + sid     = "PrivateReadOnly"

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
      + statement {
          + actions = [
              + "ecr:CompleteLayerUpload",
              + "ecr:InitiateLayerUpload",
              + "ecr:PutImage",
              + "ecr:UploadLayerPart",
            ]
          + sid     = "ReadWrite"

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # module.ecr["mlflow"].aws_ecr_lifecycle_policy.this[0] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Keep last 10 images"
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 10
                          + countType   = "imageCountMoreThan"
                          + tagStatus   = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "mlflow"
    }

  # module.ecr["mlflow"].aws_ecr_repository.this[0] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "IMMUTABLE"
      + name                 = "mlflow"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
      + tags_all             = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }

      + encryption_configuration {
          + encryption_type = "AES256"
          + kms_key         = (known after apply)
        }

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # module.ecr["mlflow"].aws_ecr_repository_policy.this[0] will be created
  + resource "aws_ecr_repository_policy" "this" {
      + id          = (known after apply)
      + policy      = (known after apply)
      + registry_id = (known after apply)
      + repository  = "mlflow"
    }

  # module.iam_policy_apprunner_access.aws_iam_policy.policy[0] will be created
  + resource "aws_iam_policy" "policy" {
      + arn         = (known after apply)
      + description = "Access to ECR to Apprunner"
      + id          = (known after apply)
      + name        = "apprunner-access-policy-dev"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchCheckLayerAvailability",
                          + "ecr:BatchGetImage",
                          + "ecr:DescribeImages",
                          + "ecr:GetAuthorizationToken",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags_all    = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }
    }

  # module.s3_assets.aws_s3_bucket.this[0] will be created
  + resource "aws_s3_bucket" "this" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = "assets-dev-"
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = false
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = {
          + "Environment" = "dev"
          + "Terraform"   = "true"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

  # module.s3_assets.aws_s3_bucket_acl.this[0] will be created
  + resource "aws_s3_bucket_acl" "this" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)
    }

  # module.s3_assets.aws_s3_bucket_cors_configuration.this[0] will be created
  + resource "aws_s3_bucket_cors_configuration" "this" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "POST",
              + "PUT",
            ]
          + allowed_origins = [
              + "*",
            ]
          + expose_headers  = [
              + "x-amz-id-2",
              + "x-amz-request-id",
              + "x-amz-server-side-encryption",
            ]
          + max_age_seconds = 3000
        }
    }

  # module.s3_assets.aws_s3_bucket_public_access_block.this[0] will be created
  + resource "aws_s3_bucket_public_access_block" "this" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # module.s3_assets.aws_s3_bucket_versioning.this[0] will be created
  + resource "aws_s3_bucket_versioning" "this" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Suspended"
        }
    }

  # module.security_group_apprunner_connector.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group for AppRunner connector"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "apprunner-connector-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "apprunner-connector"
        }
      + tags_all               = {
          + "Environment" = "dev"
          + "Name"        = "apprunner-connector"
          + "Terraform"   = "true"
        }
      + vpc_id                 = (known after apply)

      + timeouts {
          + create = "10m"
          + delete = "15m"
        }
    }

  # module.security_group_apprunner_connector.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = (known after apply)
      + description              = "HTTP"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "egress"
    }

  # module.security_group_apprunner_endpoint.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group for Apprunner VPC Endpoints"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "apprunner-vpc-endpoints-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "apprunner-vpc-endpoints"
        }
      + tags_all               = {
          + "Environment" = "dev"
          + "Name"        = "apprunner-vpc-endpoints"
          + "Terraform"   = "true"
        }
      + vpc_id                 = (known after apply)

      + timeouts {
          + create = "10m"
          + delete = "15m"
        }
    }

  # module.security_group_apprunner_endpoint.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = (known after apply)
      + description              = "HTTPS"
      + from_port                = 443
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "egress"
    }

  # module.vpc.aws_db_subnet_group.database[0] will be created
  + resource "aws_db_subnet_group" "database" {
      + arn                     = (known after apply)
      + description             = "Database subnet group for ml-dev"
      + id                      = (known after apply)
      + name                    = "ml-dev"
      + name_prefix             = (known after apply)
      + subnet_ids              = (known after apply)
      + supported_network_types = (known after apply)
      + tags                    = {
          + "Name" = "ml-dev"
        }
      + tags_all                = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev"
          + "Terraform"   = "true"
        }
      + vpc_id                  = (known after apply)
    }

  # module.vpc.aws_default_network_acl.this[0] will be created
  + resource "aws_default_network_acl" "this" {
      + arn                    = (known after apply)
      + default_network_acl_id = (known after apply)
      + id                     = (known after apply)
      + owner_id               = (known after apply)
      + tags                   = {
          + "Name" = "ml-dev-default"
        }
      + tags_all               = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-default"
          + "Terraform"   = "true"
        }
      + vpc_id                 = (known after apply)

      + egress {
          + action          = "allow"
          + from_port       = 0
          + ipv6_cidr_block = "::/0"
          + protocol        = "-1"
          + rule_no         = 101
          + to_port         = 0
        }
      + egress {
          + action     = "allow"
          + cidr_block = "0.0.0.0/0"
          + from_port  = 0
          + protocol   = "-1"
          + rule_no    = 100
          + to_port    = 0
        }

      + ingress {
          + action          = "allow"
          + from_port       = 0
          + ipv6_cidr_block = "::/0"
          + protocol        = "-1"
          + rule_no         = 101
          + to_port         = 0
        }
      + ingress {
          + action     = "allow"
          + cidr_block = "0.0.0.0/0"
          + from_port  = 0
          + protocol   = "-1"
          + rule_no    = 100
          + to_port    = 0
        }
    }

  # module.vpc.aws_default_route_table.default[0] will be created
  + resource "aws_default_route_table" "default" {
      + arn                    = (known after apply)
      + default_route_table_id = (known after apply)
      + id                     = (known after apply)
      + owner_id               = (known after apply)
      + route                  = (known after apply)
      + tags                   = {
          + "Name" = "ml-dev-default"
        }
      + tags_all               = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-default"
          + "Terraform"   = "true"
        }
      + vpc_id                 = (known after apply)

      + timeouts {
          + create = "5m"
          + update = "5m"
        }
    }

  # module.vpc.aws_default_security_group.this[0] will be created
  + resource "aws_default_security_group" "this" {
      + arn                    = (known after apply)
      + description            = (known after apply)
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "ml-dev-default"
        }
      + tags_all               = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-default"
          + "Terraform"   = "true"
        }
      + vpc_id                 = (known after apply)
    }

  # module.vpc.aws_internet_gateway.this[0] will be created
  + resource "aws_internet_gateway" "this" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags     = {
          + "Name" = "ml-dev"
        }
      + tags_all = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev"
          + "Terraform"   = "true"
        }
      + vpc_id   = (known after apply)
    }

  # module.vpc.aws_route.public_internet_gateway[0] will be created
  + resource "aws_route" "public_internet_gateway" {
      + destination_cidr_block = "0.0.0.0/0"
      + gateway_id             = (known after apply)
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)

      + timeouts {
          + create = "5m"
        }
    }

  # module.vpc.aws_route_table.private[0] will be created
  + resource "aws_route_table" "private" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name" = "ml-dev-private"
        }
      + tags_all         = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-private"
          + "Terraform"   = "true"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table.public[0] will be created
  + resource "aws_route_table" "public" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name" = "ml-dev-public"
        }
      + tags_all         = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-public"
          + "Terraform"   = "true"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table_association.database[0] will be created
  + resource "aws_route_table_association" "database" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.database[1] will be created
  + resource "aws_route_table_association" "database" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.database[2] will be created
  + resource "aws_route_table_association" "database" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.private[0] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.private[1] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.private[2] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.public[0] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.public[1] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.public[2] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_subnet.database[0] will be created
  + resource "aws_subnet" "database" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-db-eu-west-1a"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-db-eu-west-1a"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.database[1] will be created
  + resource "aws_subnet" "database" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-db-eu-west-1b"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-db-eu-west-1b"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.database[2] will be created
  + resource "aws_subnet" "database" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-db-eu-west-1c"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-db-eu-west-1c"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.private[0] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-private-eu-west-1a"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-private-eu-west-1a"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.private[1] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-private-eu-west-1b"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-private-eu-west-1b"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.private[2] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-private-eu-west-1c"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-private-eu-west-1c"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.public[0] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-public-eu-west-1a"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-public-eu-west-1a"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.public[1] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-public-eu-west-1b"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-public-eu-west-1b"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.public[2] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "eu-west-1c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = (known after apply)
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "ml-dev-public-eu-west-1c"
        }
      + tags_all                                       = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev-public-eu-west-1c"
          + "Terraform"   = "true"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_vpc.this[0] will be created
  + resource "aws_vpc" "this" {
      + arn                                  = (known after apply)
      + cidr_block                           = (known after apply)
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = true
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Name" = "ml-dev"
        }
      + tags_all                             = {
          + "Environment" = "dev"
          + "Name"        = "ml-dev"
          + "Terraform"   = "true"
        }
    }

Plan: 54 to add, 0 to change, 0 to destroy.

```